### PR TITLE
Hash the user's API key as well as their passphase

### DIFF
--- a/bin/build_schema.pl
+++ b/bin/build_schema.pl
@@ -52,11 +52,14 @@ make_schema_at(
       # make the created_ad and updated_at update automatically when the
       # relevant operation is performed on the column
       return { set_on_create => 1 } if $column_name eq 'created_at';
-      # return { set_on_update => 1 } if $column_name eq 'updated_at';
 
       # make the passphrase column treat passphrases as salted digests and
       # set the parameters for that
-      if ( $column_name eq 'passphrase' ) {
+      if ( $column_name eq 'passphrase' or
+           $column_name eq 'api_key'       ) {
+        my $method = $column_name eq 'passphrase'
+                   ? 'check_password'
+                   : 'check_api_key';
         return {
           passphrase       => 'rfc2307',
           passphrase_class => 'SaltedDigest',
@@ -64,7 +67,7 @@ make_schema_at(
             algorithm   => 'SHA-1',
             salt_random => 20,
           },
-          passphrase_check_method => 'check_password',
+          passphrase_check_method => $method,
         };
       }
     },

--- a/lib/Bio/HICF/Schema/Result/User.pm
+++ b/lib/Bio/HICF/Schema/Result/User.pm
@@ -91,6 +91,10 @@ Website roles for the current user. Default user.
 
   data_type: 'char'
   is_nullable: 1
+  passphrase: 'rfc2307'
+  passphrase_args: {algorithm => "SHA-1",salt_random => 20}
+  passphrase_check_method: 'check_api_key'
+  passphrase_class: 'SaltedDigest'
   size: 32
 
 REST API key for the user
@@ -139,7 +143,15 @@ __PACKAGE__->add_columns(
     size => 128,
   },
   "api_key",
-  { data_type => "char", is_nullable => 1, size => 32 },
+  {
+    data_type => "char",
+    is_nullable => 1,
+    passphrase => "rfc2307",
+    passphrase_args => { algorithm => "SHA-1", salt_random => 20 },
+    passphrase_check_method => "check_api_key",
+    passphrase_class => "SaltedDigest",
+    size => 32,
+  },
   "created_at",
   {
     data_type => "datetime",
@@ -181,8 +193,8 @@ __PACKAGE__->set_primary_key("username");
 with 'Bio::HICF::Schema::Role::User';
 
 
-# Created by DBIx::Class::Schema::Loader v0.07042 @ 2015-04-23 13:38:24
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:vYOStpYMckS/S9eCZgysWQ
+# Created by DBIx::Class::Schema::Loader v0.07042 @ 2015-05-06 15:44:01
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:XI8HCG9YcnZvfcI8wE1yrA
 
 
 __PACKAGE__->meta->make_immutable;


### PR DESCRIPTION
We should store the API key as a hashed digest, just as we do the
passphrase. This commit changes the schema loader script to make it add
the necessary incantations to the User table, and adds the updated
Bio::HICF::Schema::Result::User table wrapper.