### PR TITLE
Tidy tests

### DIFF
--- a/bin/load_tax_tree
+++ b/bin/load_tax_tree
@@ -85,6 +85,7 @@ $tt->build_tree;
 
 # get a database connection
 my $schema = Bio::HICF::Schema->connect( @{ $config{database}->{hicf}->{connect_info} } );
+croak "ERROR: couldn't connect to the database" unless defined $schema;
 
 # load it
 try {

--- a/lib/Bio/HICF/Schema.pm
+++ b/lib/Bio/HICF/Schema.pm
@@ -367,8 +367,8 @@ sub get_all_samples {
   my $samples_rs = $self->resultset('Sample')->search(
     {},
     {
-      join     => [qw( geolocation location_description )],
-      prefetch => [qw( geolocation location_description )]
+      join     => [ 'location_description' ],
+      prefetch => [ 'location_description' ]
     }
   );
 

--- a/lib/Bio/HICF/Schema/Result/Sample.pm
+++ b/lib/Bio/HICF/Schema/Result/Sample.pm
@@ -442,16 +442,6 @@ __PACKAGE__->add_unique_constraint(
   sample_uc => [ qw( manifest_id raw_data_accession sample_accession ) ]
 );
 
-# add some extra relationships
-
-# map the location term in this table (given as a Gazetteer ontology term) to
-# to location table, which stores the latitude and longitude for that location
-__PACKAGE__->might_have(
-  'geolocation',
-  'Bio::HICF::Schema::Result::Location',
-  { 'foreign.gaz_term' => 'self.location' },
-);
-
 # map the location term to the ontology, giving us the place description
 __PACKAGE__->might_have(
   'location_description',

--- a/t/01_schema.t
+++ b/t/01_schema.t
@@ -25,18 +25,6 @@ my $preload = sub {
 
 lives_ok { Schema->storage->dbh_do($preload) } 'successfully turned on "foreign_keys" pragma';
 
-diag 'caching ontology/taxonomy files';
-Test::CacheFile::cache( 'http://purl.obolibrary.org/obo/subsets/envo-basic.obo', 'envo-basic.obo' );
-Test::CacheFile::cache( 'http://purl.obolibrary.org/obo/gaz.obo', 'gaz.obo' );
-Test::CacheFile::cache( 'http://www.brenda-enzymes.info/ontology/tissue/tree/update/update_files/BrendaTissueOBO', 'bto.obo' );
-Test::CacheFile::cache( 'ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz', 'taxdump.tar.gz' );
-
-# extract the names.dmp from the taxdump archive
-if ( ! -f '.cached_test_files/names.dmp' ) {
-  my $tar = Archive::Tar->new('.cached_test_files/taxdump.tar.gz');
-  $tar->extract_file( 'names.dmp', '.cached_test_files/names.dmp' );
-}
-
 #-------------------------------------------------------------------------------
 
 # make sure we can retrieve samples and manifests

--- a/t/02_amr.t
+++ b/t/02_amr.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More;
+use Test::More tests => 18;
 use Test::Exception;
 use Test::DBIx::Class qw( :resultsets );
 

--- a/t/03_sample.t
+++ b/t/03_sample.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More;
+use Test::More tests => 105;
 use Test::Exception;
 use Test::DBIx::Class qw( :resultsets );
 use DateTime;

--- a/t/04_manifest.t
+++ b/t/04_manifest.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More;
+use Test::More tests => 23;
 use Test::Exception;
 use Test::DBIx::Class qw( :resultsets );
 

--- a/t/05_tax_tree.t
+++ b/t/05_tax_tree.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 
-use Test::More;
+use Test::More tests => 15;
 use Test::DBIx::Class qw( :resultsets );
 use Test::Exception;
 

--- a/t/06_load_tax_tree.t
+++ b/t/06_load_tax_tree.t
@@ -2,8 +2,7 @@
 use strict;
 use warnings;
 
-use Test::More;
-use Test::CacheFile;
+use Test::More tests => 9;
 use Test::Exception;
 use Test::Script::Run;
 

--- a/t/07_load_antimicrobials.t
+++ b/t/07_load_antimicrobials.t
@@ -2,8 +2,7 @@
 use strict;
 use warnings;
 
-use Test::More;
-use Test::CacheFile;
+use Test::More tests => 12;
 use Test::Exception;
 use Test::Script::Run;
 
@@ -68,8 +67,6 @@ unlike $stderr, qr/ERROR/,
   'no loading error with valid configs and manifest';
 
 is( Antimicrobial->count, 9, 'got expected number of rows antimicrobial table after loading' );
-
-$DB::single = 1;
 
 done_testing;
 

--- a/t/08_load_ontology.t
+++ b/t/08_load_ontology.t
@@ -2,8 +2,7 @@
 use strict;
 use warnings;
 
-use Test::More;
-use Test::CacheFile;
+use Test::More tests => 14;
 use Test::Exception;
 use Test::Script::Run;
 

--- a/t/09_password_methods.t
+++ b/t/09_password_methods.t
@@ -2,8 +2,7 @@
 use strict;
 use warnings;
 
-use Test::More;
-use Test::CacheFile;
+use Test::More tests => 40;
 use Test::Exception;
 use Test::Script::Run;
 

--- a/t/10_set_password.t
+++ b/t/10_set_password.t
@@ -2,8 +2,7 @@
 use strict;
 use warnings;
 
-use Test::More;
-use Test::CacheFile;
+use Test::More tests => 5;
 use Test::Exception;
 use Test::Script::Run;
 

--- a/t/11_file.t
+++ b/t/11_file.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More;
+use Test::More tests => 18;
 use Test::Exception;
 use Test::DBIx::Class qw( :resultsets );
 

--- a/t/12_assembly.t
+++ b/t/12_assembly.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More;
+use Test::More tests => 29;
 use Test::Exception;
 use Test::DBIx::Class qw( :resultsets );
 

--- a/t/13_load_manifest.t
+++ b/t/13_load_manifest.t
@@ -2,8 +2,7 @@
 use strict;
 use warnings;
 
-use Test::More;
-use Test::CacheFile;
+use Test::More tests => 14;
 use Test::Exception;
 use Test::Script::Run;
 
@@ -36,11 +35,6 @@ my $preload = sub {
 
 lives_ok { Schema->storage->dbh_do($preload) } 'successfully turned on "foreign_keys" pragma';
 
-diag 'caching ontology files';
-Test::CacheFile::cache( 'http://purl.obolibrary.org/obo/subsets/envo-basic.obo', 'envo-basic.obo' );
-Test::CacheFile::cache( 'http://purl.obolibrary.org/obo/gaz.obo', 'gaz.obo' );
-Test::CacheFile::cache( 'http://www.brenda-enzymes.info/ontology/tissue/tree/update/update_files/BrendaTissueOBO', 'bto.obo' );
-
 #-------------------------------------------------------------------------------
 
 my $script = 'bin/load_manifest';
@@ -60,9 +54,6 @@ SKIP: {
   ( $rv, $stdout, $stderr ) = run_script( $script, [ qw(-c t/data/13_checklist.conf        -d t/data/test_config.conf) ] );
   like( $stderr, qr/ERROR: you must specify an input file/, 'got expected error message with -c and -s flags' );
 
-  ( $rv, $stdout, $stderr ) = run_script( $script, [ qw(-c t/data/13_broken_checklist.conf -d t/data/13_script.conf             t/data/13_manifest.csv) ] );
-  like( $stderr, qr/ERROR: could not load configuration/, 'got expected error message with broken checklist config' );
-
   ( $rv, $stdout, $stderr ) = run_script( $script, [ qw(-c t/data/13_checklist.conf        -d t/data/13_broken_test_config.conf t/data/13_manifest.csv) ] );
   like( $stderr, qr/ERROR: there was a problem reading the script configuration.*? no EndBlock/, 'got expected error message with broken script config' );
 
@@ -71,6 +62,9 @@ SKIP: {
 
   ( $rv, $stdout, $stderr ) = run_script( $script, [ qw(-c t/data/13_checklist.conf        -d t/data/13_script.conf             t/data/13_broken_manifest.csv) ] );
   like( $stderr, qr/ERROR: there was a problem loading.*? data in the manifest are not valid/, 'got expected error message with invalid manifest' );
+
+  ( $rv, $stdout, $stderr ) = run_script( $script, [ qw(-c t/data/13_broken_checklist.conf -d t/data/13_script.conf             t/data/13_manifest.csv) ] );
+  like( $stderr, qr/ERROR: could not load configuration/, 'got expected error message with broken checklist config' );
 }
 
 is( Sample->count, 1, 'found one row in sample table before loading' );

--- a/t/14_sample_loader.t
+++ b/t/14_sample_loader.t
@@ -2,8 +2,7 @@
 use strict;
 use warnings;
 
-use Test::More;
-use Test::CacheFile;
+use Test::More tests => 33;
 use Test::Exception;
 use Test::Warn;
 use Test::Script::Run;
@@ -26,18 +25,6 @@ my $preload = sub {
 };
 
 lives_ok { Schema->storage->dbh_do($preload) } 'successfully turned on "foreign_keys" pragma';
-
-diag 'caching ontology/taxonomy files';
-Test::CacheFile::cache( 'http://purl.obolibrary.org/obo/subsets/envo-basic.obo', 'envo-basic.obo' );
-Test::CacheFile::cache( 'http://purl.obolibrary.org/obo/gaz.obo', 'gaz.obo' );
-Test::CacheFile::cache( 'http://www.brenda-enzymes.info/ontology/tissue/tree/update/update_files/BrendaTissueOBO', 'bto.obo' );
-Test::CacheFile::cache( 'ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz', 'taxdump.tar.gz' );
-
-# extract the names.dmp from the taxdump archive
-if ( ! -f '.cached_test_files/names.dmp' ) {
-  my $tar = Archive::Tar->new('.cached_test_files/taxdump.tar.gz');
-  $tar->extract_file( 'names.dmp', '.cached_test_files/names.dmp' );
-}
 
 # make the directories for the tests
 make_path( 't/data/storage/archive',

--- a/t/15_load_samples_cron.t
+++ b/t/15_load_samples_cron.t
@@ -2,8 +2,7 @@
 use strict;
 use warnings;
 
-use Test::More;
-use Test::CacheFile;
+use Test::More tests => 20;
 use Test::Exception;
 use Test::Script::Run;
 use File::Path qw(make_path remove_tree);
@@ -24,17 +23,6 @@ my $preload = sub {
 };
 
 lives_ok { Schema->storage->dbh_do($preload) } 'successfully turned on "foreign_keys" pragma';
-
-diag 'caching ontology files';
-Test::CacheFile::cache( 'http://purl.obolibrary.org/obo/subsets/envo-basic.obo', 'envo-basic.obo' );
-Test::CacheFile::cache( 'http://purl.obolibrary.org/obo/gaz.obo', 'gaz.obo' );
-Test::CacheFile::cache( 'http://www.brenda-enzymes.info/ontology/tissue/tree/update/update_files/BrendaTissueOBO', 'bto.obo' );
-
-# extract the names.dmp from the taxdump archive
-if ( ! -f '.cached_test_files/names.dmp' ) {
-  my $tar = Archive::Tar->new('.cached_test_files/taxdump.tar.gz');
-  $tar->extract_file( 'names.dmp', '.cached_test_files/names.dmp' );
-}
 
 # set up the location of the test directories. It's assumed that you're running
 # this test from the top-level directory of the module tree

--- a/t/16_geocode.t
+++ b/t/16_geocode.t
@@ -2,8 +2,7 @@
 use strict;
 use warnings;
 
-use Test::More;
-use Test::CacheFile;
+use Test::More tests => 22;
 use Test::Exception;
 use Test::Script::Run;
 use Test::MockModule;

--- a/t/data/01_bto.obo
+++ b/t/data/01_bto.obo
@@ -1,0 +1,37 @@
+format-version: 1.2
+date: 22:10:2014 18:45
+saved-by: Marion
+auto-generated-by: OBO-Edit 2.3-beta5
+synonymtypedef: GE "LANGUAGE GERMAN"
+synonymtypedef: SCI "SCIENTIFIC NAME"
+default-namespace:
+
+[Term]
+id: BTO:0000644
+name: intestinal juice
+namespace: BrendaTissueOBO
+def: "A fluid that is secreted in small quantity in the small intestine, is highly variable in constitution, and contains especially various enzymes (as erepsin, lipase, lactase, enterokinase, and amylase) and mucus." [Fast_Health_Medical_Dictionary:http\://www.fasthealth.com/dictionary/]
+synonym: "succus entericus" RELATED []
+is_a: BTO:0000346 ! digestive juice
+relationship: develops_from BTO:0000640 ! intestinal gland
+relationship: related_to BTO:0000651 ! small intestine
+
+[Term]
+id: BTO:0000645
+name: colon sigmoideum
+namespace: BrendaTissueOBO
+def: "The S-shaped part of the colon which lies in the pelvis, extending from the pelvic brim to the third segment of the sacrum, and continuous above with the descending (or iliac) colon and below with the rectum." [Dorlands_Medical_Dictionary:MerckSource]
+synonym: "pelvic colon" RELATED []
+synonym: "sigmoid colon" RELATED []
+synonym: "sigmoid flexure" RELATED []
+relationship: part_of BTO:0000269 ! colon
+
+[Term]
+id: BTO:0000646
+name: left colon
+namespace: BrendaTissueOBO
+def: "The distal portion of the colon; it develops embryonically from the hindgut and functions in the storage and elimination of waste." [Dorlands_Medical_Dictionary:MerckSource]
+synonym: "distal colon" RELATED []
+relationship: develops_from BTO:0000510 ! hindgut
+relationship: part_of BTO:0000269 ! colon
+

--- a/t/data/01_checklist.conf
+++ b/t/data/01_checklist.conf
@@ -76,7 +76,7 @@
     name         location
     description  'Locality of isolation of the sampled organism indicated in terms of political names for nations, oceans or seas, followed by regions and localities. Must be a term from the GAZ ontology.'
     type         Ontology
-    path         .cached_test_files/gaz.obo
+    path         t/data/01_gaz.obo
     required     1
   </field>
   <field>
@@ -102,7 +102,7 @@
     name         host_isolation_source
     description  'Name of host tissue or organ sampled for analysis. Must be a term from the BRENDA ontology.'
     type         Ontology
-    path         .cached_test_files/bto.obo
+    path         t/data/01_bto.obo
   </field>
   <field>
     name         patient_location
@@ -115,7 +115,7 @@
     name         isolation_source
     description  'Describes the physical, environmental and/or local geographical source of the biological sample from which the sample was derived. Must be a term from the EnvO ontology.'
     type         Ontology
-    path         .cached_test_files/envo-basic.obo
+    path         t/data/01_envo.obo
   </field>
   <field>
     name         serovar

--- a/t/data/01_envo.obo
+++ b/t/data/01_envo.obo
@@ -1,0 +1,33 @@
+format-version: 1.2
+subsetdef: disposition_slim "Disposition slim"
+subsetdef: mpath_slim "Pathology slim"
+subsetdef: relational_slim "Relational slim: types of quality that require an additional entity in order to exist"
+subsetdef: scalar_slim "Scalar slim"
+subsetdef: value_slim "Value slim"
+default-namespace: ENVO
+ontology: subsets/envo-basic.obo
+
+[Term]
+id: ENVO:00000000
+name: geographic feature
+comment: May appear on a map.
+synonym: "macroscopic spatial feature" EXACT []
+xref: Wikipedia:Geographic_feature
+is_a: ENVO:00002297 ! environmental feature
+
+[Term]
+id: ENVO:00000001
+name: bedding-plane cave
+def: "A cavity developed along a bedding-plane and elongate in cross-section as a result." [web:http\://wasg.u/terminol.html]
+is_a: ENVO:00000067 ! cave
+
+[Term]
+id: ENVO:00000002
+name: anthropogenic geographic feature
+def: "An anthropogenic geographic feature is a geographic feature\nresulting from the influence of human beings on nature." [ORCID:0000-0002-4366-3088]
+synonym: "man-made feature" RELATED []
+synonym: "manmade feature" RELATED []
+xref: FTT:78
+xref: TGN:50001
+is_a: ENVO:00000000 ! geographic feature
+

--- a/t/data/04_bto.obo
+++ b/t/data/04_bto.obo
@@ -1,0 +1,37 @@
+format-version: 1.2
+date: 22:10:2014 18:45
+saved-by: Marion
+auto-generated-by: OBO-Edit 2.3-beta5
+synonymtypedef: GE "LANGUAGE GERMAN"
+synonymtypedef: SCI "SCIENTIFIC NAME"
+default-namespace:
+
+[Term]
+id: BTO:0000644
+name: intestinal juice
+namespace: BrendaTissueOBO
+def: "A fluid that is secreted in small quantity in the small intestine, is highly variable in constitution, and contains especially various enzymes (as erepsin, lipase, lactase, enterokinase, and amylase) and mucus." [Fast_Health_Medical_Dictionary:http\://www.fasthealth.com/dictionary/]
+synonym: "succus entericus" RELATED []
+is_a: BTO:0000346 ! digestive juice
+relationship: develops_from BTO:0000640 ! intestinal gland
+relationship: related_to BTO:0000651 ! small intestine
+
+[Term]
+id: BTO:0000645
+name: colon sigmoideum
+namespace: BrendaTissueOBO
+def: "The S-shaped part of the colon which lies in the pelvis, extending from the pelvic brim to the third segment of the sacrum, and continuous above with the descending (or iliac) colon and below with the rectum." [Dorlands_Medical_Dictionary:MerckSource]
+synonym: "pelvic colon" RELATED []
+synonym: "sigmoid colon" RELATED []
+synonym: "sigmoid flexure" RELATED []
+relationship: part_of BTO:0000269 ! colon
+
+[Term]
+id: BTO:0000646
+name: left colon
+namespace: BrendaTissueOBO
+def: "The distal portion of the colon; it develops embryonically from the hindgut and functions in the storage and elimination of waste." [Dorlands_Medical_Dictionary:MerckSource]
+synonym: "distal colon" RELATED []
+relationship: develops_from BTO:0000510 ! hindgut
+relationship: part_of BTO:0000269 ! colon
+

--- a/t/data/04_checklist.conf
+++ b/t/data/04_checklist.conf
@@ -76,7 +76,7 @@
     name         location
     description  'Locality of isolation of the sampled organism indicated in terms of political names for nations, oceans or seas, followed by regions and localities. Must be a term from the GAZ ontology.'
     type         Ontology
-    path         .cached_test_files/gaz.obo
+    path         t/data/04_gaz.obo
     required     1
   </field>
   <field>
@@ -102,7 +102,7 @@
     name         host_isolation_source
     description  'Name of host tissue or organ sampled for analysis. Must be a term from the BRENDA ontology.'
     type         Ontology
-    path         .cached_test_files/bto.obo
+    path         t/data/04_bto.obo
   </field>
   <field>
     name         patient_location
@@ -115,7 +115,7 @@
     name         isolation_source
     description  'Describes the physical, environmental and/or local geographical source of the biological sample from which the sample was derived. Must be a term from the EnvO ontology.'
     type         Ontology
-    path         .cached_test_files/envo-basic.obo
+    path         t/data/04_envo.obo
   </field>
   <field>
     name         serovar

--- a/t/data/04_envo.obo
+++ b/t/data/04_envo.obo
@@ -1,0 +1,33 @@
+format-version: 1.2
+subsetdef: disposition_slim "Disposition slim"
+subsetdef: mpath_slim "Pathology slim"
+subsetdef: relational_slim "Relational slim: types of quality that require an additional entity in order to exist"
+subsetdef: scalar_slim "Scalar slim"
+subsetdef: value_slim "Value slim"
+default-namespace: ENVO
+ontology: subsets/envo-basic.obo
+
+[Term]
+id: ENVO:00000000
+name: geographic feature
+comment: May appear on a map.
+synonym: "macroscopic spatial feature" EXACT []
+xref: Wikipedia:Geographic_feature
+is_a: ENVO:00002297 ! environmental feature
+
+[Term]
+id: ENVO:00000001
+name: bedding-plane cave
+def: "A cavity developed along a bedding-plane and elongate in cross-section as a result." [web:http\://wasg.u/terminol.html]
+is_a: ENVO:00000067 ! cave
+
+[Term]
+id: ENVO:00000002
+name: anthropogenic geographic feature
+def: "An anthropogenic geographic feature is a geographic feature\nresulting from the influence of human beings on nature." [ORCID:0000-0002-4366-3088]
+synonym: "man-made feature" RELATED []
+synonym: "manmade feature" RELATED []
+xref: FTT:78
+xref: TGN:50001
+is_a: ENVO:00000000 ! geographic feature
+

--- a/t/data/04_gaz.obo
+++ b/t/data/04_gaz.obo
@@ -1,0 +1,152 @@
+format-version: 1.2
+date: 23:12:2013 14:47
+saved-by: michaelashburner
+auto-generated-by: OBO-Edit 2.3-beta5
+synonymtypedef: ABBREVIATION "ABBREVIATION" EXACT
+synonymtypedef: COLLOQUIAL_NAME "COLLOQUIAL NAME" EXACT
+synonymtypedef: FORMAL_NAME "FORMAL NAME" EXACT
+synonymtypedef: FORMER_NAME "FORMER NAME" EXACT
+synonymtypedef: LAPSUS "LAPSUS" EXACT
+synonymtypedef: SPELLING_VARIANT "SPELLING VARIANT" EXACT
+default-namespace: file:/Users/michaelashburner/Desktop/gaz/gaz.obo
+remark: This is an alpha version and is only for experimental implementation.
+remark: Comments etc to Michael Ashburner, ma11@gen.cam.ac.uk
+remark: Acknowledgements and sources: A large number of sources have been, and are being, used to build gaz.obo. By far
+remark: the most used are the pages of Wikipedia, which seem to be quite accurate in this domain. Thanks to all
+remark: of those who contribute to this invaluable resource. In addition, a number of other sources have been
+remark: used quite extensively and I wish to acknowledge, with thanks, the following (which is not exhaustive):
+remark: ...
+
+[Term]
+id: GAZ:00444173
+name: Swaffham Bulbeck Lode
+namespace: GAZ
+def: "A man-made channel. A lode." [url:http\://en.wikipedia.org/wiki/Cambridgeshire_Lodes]
+relationship: connected_to GAZ:00442461 ! River Cam
+relationship: located_in GAZ:00444137 ! Civil Parish of Swaffham Bulbeck
+created_by: michaelashburner
+creation_date: 2011-07-02T10:53:07Z
+
+[Term]
+id: GAZ:00444174
+name: Reach Lode
+namespace: GAZ
+def: "A man-made waterway. A lode." [url:http\://en.wikipedia.org/wiki/Cambridgeshire_Lodes]
+relationship: connected_to GAZ:00442461 ! River Cam
+relationship: partial_overlaps GAZ:00444141 ! Civil Parish of Reach
+relationship: partial_overlaps GAZ:00444215 ! Upware
+created_by: michaelashburner
+creation_date: 2011-07-02T10:53:07Z
+
+[Term]
+id: GAZ:00444175
+name: River Rhee
+namespace: GAZ
+def: "A river. It begins just off the High Street (Ashwell Springs), Ashwell in Hertfordshire running north then east 19 km through the farmland of southern Cambridgeshire." [url:http\://en.wikipedia.org/wiki/River_Cam#ref_map_12]
+relationship: partial_overlaps GAZ:00443226 ! Civil Parish of Ashwell
+relationship: tributary_of GAZ:00442461 ! River Cam
+created_by: michaelashburner
+creation_date: 2011-07-02T10:55:23Z
+
+[Term]
+id: GAZ:00444176
+name: River Granta [Essex]
+namespace: GAZ
+def: "A river. It starts near the village of Widdington in Essex flowing the 24 km north past Audley End House to merge with the Rhee a mile south of Grantchester." [url:http\://en.wikipedia.org/wiki/River_Cam#ref_map_12]
+relationship: partial_overlaps GAZ:00443944 ! Civil Parish of Great Shelford
+relationship: tributary_of GAZ:00444175 ! River Rhee
+created_by: michaelashburner
+creation_date: 2011-07-02T10:57:35Z
+
+[Term]
+id: GAZ:00444177
+name: River Granta [Haverhill]
+namespace: GAZ
+def: "A river." [url:http\://en.wikipedia.org/wiki/River_Cam#ref_map_12]
+relationship: partial_overlaps GAZ:00443963 ! Civil Parish of Linton
+relationship: tributary_of GAZ:00444176 ! River Granta [Essex]
+created_by: michaelashburner
+creation_date: 2011-07-02T10:59:29Z
+
+[Term]
+id: GAZ:00444178
+name: Byron's Pool
+namespace: GAZ
+alt_id: GAZ:00007815
+def: "A weir pool. A protected area." [url:http\://lnr.cambridge.gov.uk/reserves/byrons_pool/]
+synonym: "Byron's Pool" EXACT []
+relationship: located_in GAZ:00007814 ! Granchester
+relationship: located_in GAZ:00442461 ! River Cam
+created_by: michaelashburner
+creation_date: 2011-07-02T11:03:35Z
+
+[Term]
+id: GAZ:00444179
+name: Wellcome Trust Genome Campus
+namespace: GAZ
+def: "A scientific research campus." [url:http\://en.wikipedia.org/wiki/Wellcome_Trust_Genome_Campus]
+relationship: located_in GAZ:00443954 ! Civil Parish of Hinxton
+created_by: michaelashburner
+creation_date: 2011-07-02T11:14:42Z
+
+[Term]
+id: GAZ:00444180
+name: Wellcome Trust Sanger Institute
+namespace: GAZ
+def: "Anon-profit, genomics and genetics research institute, primarily funded by the Wellcome Trust." [url:http\://en.wikipedia.org/wiki/Wellcome_Trust_Sanger_Institute]
+synonym: "Sanger Centre" EXACT FORMER_NAME []
+relationship: located_in GAZ:00444179 ! Wellcome Trust Genome Campus
+created_by: michaelashburner
+creation_date: 2011-07-02T11:16:31Z
+
+[Term]
+id: GAZ:00444181
+name: European Bioinformatics Institute
+namespace: GAZ
+def: "A centre for research and services in bioinformatics, and is part of European Molecular Biology Laboratory (EMBL)." [url:http\://en.wikipedia.org/wiki/European_Bioinformatics_Institute]
+relationship: located_in GAZ:00444179 ! Wellcome Trust Genome Campus
+created_by: michaelashburner
+creation_date: 2011-07-02T11:16:31Z
+
+[Term]
+id: GAZ:00444182
+name: Babraham Institute
+namespace: GAZ
+def: "A life sciences institute involved in biomedical research." [url:http\://en.wikipedia.org/wiki/Babraham_Institute]
+relationship: located_in GAZ:00443907 ! Civil Parish of Babraham
+created_by: michaelashburner
+creation_date: 2011-07-02T11:18:56Z
+
+[Term]
+id: GAZ:00444183
+name: Royal Society for the Protection of Birds Fowlmere
+namespace: GAZ
+def: "A protected area; a former watercress farm." [url:http\://www.rspb.org.uk/reserves/guide/f/fowlmere/index.aspx]
+relationship: located_in GAZ:00443934 ! Civil Parish of Fowlmere
+created_by: michaelashburner
+creation_date: 2011-07-02T11:20:58Z
+
+[Term]
+id: GAZ:00444184
+name: Fowlmere Airfield
+namespace: GAZ
+def: "An airfield." [url:http\://en.wikipedia.org/wiki/Fowlmere]
+xref: ICAO:EGMA
+relationship: located_in GAZ:00443934 ! Civil Parish of Fowlmere
+created_by: michaelashburner
+creation_date: 2011-07-02T11:22:43Z
+
+[Term]
+id: GAZ:00444185
+name: Cherry Hinton
+namespace: GAZ
+def: "A suburban area of the city of Cambridge, in Cambridgeshire." [url:http\://en.wikipedia.org/wiki/Cherry_Hinton]
+relationship: located_in GAZ:00004832 ! Cambridge
+created_by: michaelashburner
+creation_date: 2011-07-02T11:28:09Z
+
+[Typedef]
+id: adjacent_to
+name: adjacent_to
+xref: RO:0002220
+is_symmetric: true

--- a/t/data/06_tax_tree.conf
+++ b/t/data/06_tax_tree.conf
@@ -1,7 +1,9 @@
 <database>
-  connect_info dbi:SQLite:dbname=test.db
-  connect_info ""
-  connect_info ""
+  <hicf>
+    connect_info dbi:SQLite:dbname=test.db
+    connect_info ""
+    connect_info ""
+  </hicf>
 </database>
 <taxdump>
   url  https://github.com/sanger-pathogens/Bio-HICF-Schema/raw/master/t/data/06_taxdump.tar.gz

--- a/t/data/07_antimicrobials.conf
+++ b/t/data/07_antimicrobials.conf
@@ -1,5 +1,7 @@
 <database>
-  connect_info dbi:SQLite:dbname=test.db
-  connect_info ""
-  connect_info ""
+  <hicf>
+    connect_info dbi:SQLite:dbname=test.db
+    connect_info ""
+    connect_info ""
+  </hicf>
 </database>

--- a/t/data/08_db.conf
+++ b/t/data/08_db.conf
@@ -1,7 +1,9 @@
 <database>
-  connect_info dbi:SQLite:dbname=test.db
-  connect_info ""
-  connect_info ""
+  <hicf>
+    connect_info dbi:SQLite:dbname=test.db
+    connect_info ""
+    connect_info ""
+  </hicf>
 </database>
 <ontology>
   gazetteer http://gaz.obo

--- a/t/data/13_bad_db_script.conf
+++ b/t/data/13_bad_db_script.conf
@@ -1,5 +1,7 @@
 <database>
-  connect_info dbi:SQLite:dbname=nonexistent.db
-  connect_info ""
-  connect_info ""
+  <hicf>
+    connect_info dbi:SQLite:dbname=nonexistent.db
+    connect_info ""
+    connect_info ""
+  </hicf>
 </database>

--- a/t/data/13_bto.obo
+++ b/t/data/13_bto.obo
@@ -1,0 +1,37 @@
+format-version: 1.2
+date: 22:10:2014 18:45
+saved-by: Marion
+auto-generated-by: OBO-Edit 2.3-beta5
+synonymtypedef: GE "LANGUAGE GERMAN"
+synonymtypedef: SCI "SCIENTIFIC NAME"
+default-namespace:
+
+[Term]
+id: BTO:0000644
+name: intestinal juice
+namespace: BrendaTissueOBO
+def: "A fluid that is secreted in small quantity in the small intestine, is highly variable in constitution, and contains especially various enzymes (as erepsin, lipase, lactase, enterokinase, and amylase) and mucus." [Fast_Health_Medical_Dictionary:http\://www.fasthealth.com/dictionary/]
+synonym: "succus entericus" RELATED []
+is_a: BTO:0000346 ! digestive juice
+relationship: develops_from BTO:0000640 ! intestinal gland
+relationship: related_to BTO:0000651 ! small intestine
+
+[Term]
+id: BTO:0000645
+name: colon sigmoideum
+namespace: BrendaTissueOBO
+def: "The S-shaped part of the colon which lies in the pelvis, extending from the pelvic brim to the third segment of the sacrum, and continuous above with the descending (or iliac) colon and below with the rectum." [Dorlands_Medical_Dictionary:MerckSource]
+synonym: "pelvic colon" RELATED []
+synonym: "sigmoid colon" RELATED []
+synonym: "sigmoid flexure" RELATED []
+relationship: part_of BTO:0000269 ! colon
+
+[Term]
+id: BTO:0000646
+name: left colon
+namespace: BrendaTissueOBO
+def: "The distal portion of the colon; it develops embryonically from the hindgut and functions in the storage and elimination of waste." [Dorlands_Medical_Dictionary:MerckSource]
+synonym: "distal colon" RELATED []
+relationship: develops_from BTO:0000510 ! hindgut
+relationship: part_of BTO:0000269 ! colon
+

--- a/t/data/13_checklist.conf
+++ b/t/data/13_checklist.conf
@@ -76,7 +76,7 @@
     name         location
     description  'Locality of isolation of the sampled organism indicated in terms of political names for nations, oceans or seas, followed by regions and localities. Must be a term from the GAZ ontology.'
     type         Ontology
-    path         .cached_test_files/gaz.obo
+    path         t/data/13_gaz.obo
     required     1
   </field>
   <field>
@@ -102,7 +102,7 @@
     name         host_isolation_source
     description  'Name of host tissue or organ sampled for analysis. Must be a term from the BRENDA ontology.'
     type         Ontology
-    path         .cached_test_files/bto.obo
+    path         t/data/13_bto.obo
   </field>
   <field>
     name         patient_location
@@ -115,7 +115,7 @@
     name         isolation_source
     description  'Describes the physical, environmental and/or local geographical source of the biological sample from which the sample was derived. Must be a term from the EnvO ontology.'
     type         Ontology
-    path         .cached_test_files/envo-basic.obo
+    path         t/data/13_envo-basic.obo
   </field>
   <field>
     name         serovar

--- a/t/data/13_envo.obo
+++ b/t/data/13_envo.obo
@@ -1,0 +1,33 @@
+format-version: 1.2
+subsetdef: disposition_slim "Disposition slim"
+subsetdef: mpath_slim "Pathology slim"
+subsetdef: relational_slim "Relational slim: types of quality that require an additional entity in order to exist"
+subsetdef: scalar_slim "Scalar slim"
+subsetdef: value_slim "Value slim"
+default-namespace: ENVO
+ontology: subsets/envo-basic.obo
+
+[Term]
+id: ENVO:00000000
+name: geographic feature
+comment: May appear on a map.
+synonym: "macroscopic spatial feature" EXACT []
+xref: Wikipedia:Geographic_feature
+is_a: ENVO:00002297 ! environmental feature
+
+[Term]
+id: ENVO:00000001
+name: bedding-plane cave
+def: "A cavity developed along a bedding-plane and elongate in cross-section as a result." [web:http\://wasg.u/terminol.html]
+is_a: ENVO:00000067 ! cave
+
+[Term]
+id: ENVO:00000002
+name: anthropogenic geographic feature
+def: "An anthropogenic geographic feature is a geographic feature\nresulting from the influence of human beings on nature." [ORCID:0000-0002-4366-3088]
+synonym: "man-made feature" RELATED []
+synonym: "manmade feature" RELATED []
+xref: FTT:78
+xref: TGN:50001
+is_a: ENVO:00000000 ! geographic feature
+

--- a/t/data/13_gaz.obo
+++ b/t/data/13_gaz.obo
@@ -1,0 +1,152 @@
+format-version: 1.2
+date: 23:12:2013 14:47
+saved-by: michaelashburner
+auto-generated-by: OBO-Edit 2.3-beta5
+synonymtypedef: ABBREVIATION "ABBREVIATION" EXACT
+synonymtypedef: COLLOQUIAL_NAME "COLLOQUIAL NAME" EXACT
+synonymtypedef: FORMAL_NAME "FORMAL NAME" EXACT
+synonymtypedef: FORMER_NAME "FORMER NAME" EXACT
+synonymtypedef: LAPSUS "LAPSUS" EXACT
+synonymtypedef: SPELLING_VARIANT "SPELLING VARIANT" EXACT
+default-namespace: file:/Users/michaelashburner/Desktop/gaz/gaz.obo
+remark: This is an alpha version and is only for experimental implementation.
+remark: Comments etc to Michael Ashburner, ma11@gen.cam.ac.uk
+remark: Acknowledgements and sources: A large number of sources have been, and are being, used to build gaz.obo. By far
+remark: the most used are the pages of Wikipedia, which seem to be quite accurate in this domain. Thanks to all
+remark: of those who contribute to this invaluable resource. In addition, a number of other sources have been
+remark: used quite extensively and I wish to acknowledge, with thanks, the following (which is not exhaustive):
+remark: ...
+
+[Term]
+id: GAZ:00444173
+name: Swaffham Bulbeck Lode
+namespace: GAZ
+def: "A man-made channel. A lode." [url:http\://en.wikipedia.org/wiki/Cambridgeshire_Lodes]
+relationship: connected_to GAZ:00442461 ! River Cam
+relationship: located_in GAZ:00444137 ! Civil Parish of Swaffham Bulbeck
+created_by: michaelashburner
+creation_date: 2011-07-02T10:53:07Z
+
+[Term]
+id: GAZ:00444174
+name: Reach Lode
+namespace: GAZ
+def: "A man-made waterway. A lode." [url:http\://en.wikipedia.org/wiki/Cambridgeshire_Lodes]
+relationship: connected_to GAZ:00442461 ! River Cam
+relationship: partial_overlaps GAZ:00444141 ! Civil Parish of Reach
+relationship: partial_overlaps GAZ:00444215 ! Upware
+created_by: michaelashburner
+creation_date: 2011-07-02T10:53:07Z
+
+[Term]
+id: GAZ:00444175
+name: River Rhee
+namespace: GAZ
+def: "A river. It begins just off the High Street (Ashwell Springs), Ashwell in Hertfordshire running north then east 19 km through the farmland of southern Cambridgeshire." [url:http\://en.wikipedia.org/wiki/River_Cam#ref_map_12]
+relationship: partial_overlaps GAZ:00443226 ! Civil Parish of Ashwell
+relationship: tributary_of GAZ:00442461 ! River Cam
+created_by: michaelashburner
+creation_date: 2011-07-02T10:55:23Z
+
+[Term]
+id: GAZ:00444176
+name: River Granta [Essex]
+namespace: GAZ
+def: "A river. It starts near the village of Widdington in Essex flowing the 24 km north past Audley End House to merge with the Rhee a mile south of Grantchester." [url:http\://en.wikipedia.org/wiki/River_Cam#ref_map_12]
+relationship: partial_overlaps GAZ:00443944 ! Civil Parish of Great Shelford
+relationship: tributary_of GAZ:00444175 ! River Rhee
+created_by: michaelashburner
+creation_date: 2011-07-02T10:57:35Z
+
+[Term]
+id: GAZ:00444177
+name: River Granta [Haverhill]
+namespace: GAZ
+def: "A river." [url:http\://en.wikipedia.org/wiki/River_Cam#ref_map_12]
+relationship: partial_overlaps GAZ:00443963 ! Civil Parish of Linton
+relationship: tributary_of GAZ:00444176 ! River Granta [Essex]
+created_by: michaelashburner
+creation_date: 2011-07-02T10:59:29Z
+
+[Term]
+id: GAZ:00444178
+name: Byron's Pool
+namespace: GAZ
+alt_id: GAZ:00007815
+def: "A weir pool. A protected area." [url:http\://lnr.cambridge.gov.uk/reserves/byrons_pool/]
+synonym: "Byron's Pool" EXACT []
+relationship: located_in GAZ:00007814 ! Granchester
+relationship: located_in GAZ:00442461 ! River Cam
+created_by: michaelashburner
+creation_date: 2011-07-02T11:03:35Z
+
+[Term]
+id: GAZ:00444179
+name: Wellcome Trust Genome Campus
+namespace: GAZ
+def: "A scientific research campus." [url:http\://en.wikipedia.org/wiki/Wellcome_Trust_Genome_Campus]
+relationship: located_in GAZ:00443954 ! Civil Parish of Hinxton
+created_by: michaelashburner
+creation_date: 2011-07-02T11:14:42Z
+
+[Term]
+id: GAZ:00444180
+name: Wellcome Trust Sanger Institute
+namespace: GAZ
+def: "Anon-profit, genomics and genetics research institute, primarily funded by the Wellcome Trust." [url:http\://en.wikipedia.org/wiki/Wellcome_Trust_Sanger_Institute]
+synonym: "Sanger Centre" EXACT FORMER_NAME []
+relationship: located_in GAZ:00444179 ! Wellcome Trust Genome Campus
+created_by: michaelashburner
+creation_date: 2011-07-02T11:16:31Z
+
+[Term]
+id: GAZ:00444181
+name: European Bioinformatics Institute
+namespace: GAZ
+def: "A centre for research and services in bioinformatics, and is part of European Molecular Biology Laboratory (EMBL)." [url:http\://en.wikipedia.org/wiki/European_Bioinformatics_Institute]
+relationship: located_in GAZ:00444179 ! Wellcome Trust Genome Campus
+created_by: michaelashburner
+creation_date: 2011-07-02T11:16:31Z
+
+[Term]
+id: GAZ:00444182
+name: Babraham Institute
+namespace: GAZ
+def: "A life sciences institute involved in biomedical research." [url:http\://en.wikipedia.org/wiki/Babraham_Institute]
+relationship: located_in GAZ:00443907 ! Civil Parish of Babraham
+created_by: michaelashburner
+creation_date: 2011-07-02T11:18:56Z
+
+[Term]
+id: GAZ:00444183
+name: Royal Society for the Protection of Birds Fowlmere
+namespace: GAZ
+def: "A protected area; a former watercress farm." [url:http\://www.rspb.org.uk/reserves/guide/f/fowlmere/index.aspx]
+relationship: located_in GAZ:00443934 ! Civil Parish of Fowlmere
+created_by: michaelashburner
+creation_date: 2011-07-02T11:20:58Z
+
+[Term]
+id: GAZ:00444184
+name: Fowlmere Airfield
+namespace: GAZ
+def: "An airfield." [url:http\://en.wikipedia.org/wiki/Fowlmere]
+xref: ICAO:EGMA
+relationship: located_in GAZ:00443934 ! Civil Parish of Fowlmere
+created_by: michaelashburner
+creation_date: 2011-07-02T11:22:43Z
+
+[Term]
+id: GAZ:00444185
+name: Cherry Hinton
+namespace: GAZ
+def: "A suburban area of the city of Cambridge, in Cambridgeshire." [url:http\://en.wikipedia.org/wiki/Cherry_Hinton]
+relationship: located_in GAZ:00004832 ! Cambridge
+created_by: michaelashburner
+creation_date: 2011-07-02T11:28:09Z
+
+[Typedef]
+id: adjacent_to
+name: adjacent_to
+xref: RO:0002220
+is_symmetric: true

--- a/t/data/13_script.conf
+++ b/t/data/13_script.conf
@@ -1,5 +1,7 @@
 <database>
-  connect_info dbi:SQLite:dbname=test.db
-  connect_info ""
-  connect_info ""
+  <hicf>
+    connect_info dbi:SQLite:dbname=test.db
+    connect_info ""
+    connect_info ""
+  </hicf>
 </database>

--- a/t/data/14_script.conf
+++ b/t/data/14_script.conf
@@ -1,7 +1,9 @@
 <database>
-  connect_info dbi:SQLite:dbname=test.db
-  connect_info ""
-  connect_info ""
+  <hicf>
+    connect_info dbi:SQLite:dbname=test.db
+    connect_info ""
+    connect_info ""
+  </hicf>
 </database>
 <storage>
   dropbox $HICF_STORAGE/t/data/storage/dropbox

--- a/t/data/15_cron.conf
+++ b/t/data/15_cron.conf
@@ -1,7 +1,9 @@
 <database>
-  connect_info dbi:SQLite:dbname=test.db
-  connect_info ""
-  connect_info ""
+  <hicf>
+    connect_info dbi:SQLite:dbname=test.db
+    connect_info ""
+    connect_info ""
+  </hicf>
 </database>
 <storage>
   dropbox $HICF_STORAGE/t/data/storage/dropbox

--- a/t/data/16_script.conf
+++ b/t/data/16_script.conf
@@ -1,5 +1,7 @@
 <database>
-  connect_info dbi:SQLite:dbname=test.db
-  connect_info ""
-  connect_info ""
+  <hicf>
+    connect_info dbi:SQLite:dbname=test.db
+    connect_info ""
+    connect_info ""
+  </hicf>
 </database>


### PR DESCRIPTION
This merge removes the requirement to download and cache external data files (ontologies, taxonomy data) and switches to using cut-down local copies. This avoids the need for tests to pull down large files and therefore speeds up the tests, hopefully making them more amenable to running under CI when the time comes.

The bulk of the changes are due to the addition of new copies of the test data files, plus a tweak to the "use Test::More" lines to add a test plan.

This branch also rolls back a recent addition to the definition of the "sample" table, removing a relationship to the "location" table which causes problems with testing using SQLite.