### PR TITLE
Tweak a script and make test pass on linux as well as OSX

### DIFF
--- a/bin/add_multiple_midas_users
+++ b/bin/add_multiple_midas_users
@@ -58,6 +58,8 @@ open ( FILE, $file )
   or croak "ERROR: couldn't open file of user details: $!";
 
 while ( <FILE> ) {
+  next if m/^#/;
+
   my ( $name, $username, $email_address ) = split /,/;
   chomp $email_address;
 
@@ -72,8 +74,8 @@ while ( <FILE> ) {
     $returned_passphrase = $schema->add_new_user($user_details);
   } catch {
     warn "WARNING: something went wrong when adding new user '$username': $_";
-    next;
   };
+  next unless $returned_passphrase;
 
   # get back a User object, so that we can set an API key
   my $user = $schema->resultset('User')->find($username);

--- a/lib/Bio/HICF/Schema/ResultSet/AntimicrobialResistance.pm
+++ b/lib/Bio/HICF/Schema/ResultSet/AntimicrobialResistance.pm
@@ -77,7 +77,7 @@ sub load {
   try {
     $amr->insert;
   } catch {
-    if ( m/FOREIGN KEY constraint failed/ ) {
+    if ( m/FOREIGN KEY constraint failed/i ) {
       croak 'ERROR: both the antimicrobial and the sample must exist';
     }
     else {


### PR DESCRIPTION
This commit adds a couple of trivial checks to the script that adds multiple users to the MIDAS user database, and fixes a problem with one of the DBIC classes that causes it to fail tests on linux.