### PR TITLE
Fix AMR regex

### DIFF
--- a/lib/Bio/HICF/Schema/ResultSet/Sample.pm
+++ b/lib/Bio/HICF/Schema/ResultSet/Sample.pm
@@ -144,16 +144,17 @@ sub _parse_amr_string {
     { isa => AMRString },
   );
 
-  # TODO use Type::Tiny to set up a library and put this regex in there
+  # TODO use the Bio::Metadata::Types library to validate the AMR string,
+  # TODO rather than carrying around the regex
   my $amr = [];
-  while ( $amr_string =~ m/(([A-Za-z0-9\-\/\(\)\s]+);([SIRU]);(lt|le|eq|gt|ge)?(\d+)(;(\w+))?),?\s*/g) {
+  while ( $amr_string =~ m/^((([A-Za-z0-9\-\/\(\)\s]+);([SIRU])(;(?=[\w;])((lt|le|eq|gt|ge)?(((\d+)?\.)?\d+))?(;(\w+))?)?),?\s*)+$/g) {
     push @$amr,
       {
         antimicrobial_name => lc $2,
         susceptibility     => uc $3,
         mic                => $5,
         equality           => lc( $4 || 'eq' ),
-        method             => $7
+        method             => $12
       };
   }
   return $amr;

--- a/lib/Bio/HICF/Schema/ResultSet/Sample.pm
+++ b/lib/Bio/HICF/Schema/ResultSet/Sample.pm
@@ -144,10 +144,9 @@ sub _parse_amr_string {
     { isa => AMRString },
   );
 
-  # TODO there must be a way to put a big regex like this into a common file
-  # TODO like the Types module, rather than having to cart it around like this
+  # TODO use Type::Tiny to set up a library and put this regex in there
   my $amr = [];
-  while ( $amr_string =~ m/(([A-Za-z0-9\-\/\(\)\s]+);([SIR]);(lt|le|eq|gt|ge)?(\d+)(;(\w+))?),?\s*/g) {
+  while ( $amr_string =~ m/(([A-Za-z0-9\-\/\(\)\s]+);([SIRU]);(lt|le|eq|gt|ge)?(\d+)(;(\w+))?),?\s*/g) {
     push @$amr,
       {
         antimicrobial_name => lc $2,

--- a/lib/Bio/HICF/Schema/ResultSet/Sample.pm
+++ b/lib/Bio/HICF/Schema/ResultSet/Sample.pm
@@ -145,16 +145,17 @@ sub _parse_amr_string {
   );
 
   # TODO use the Bio::Metadata::Types library to validate the AMR string,
-  # TODO rather than carrying around the regex
+  # TODO rather than carrying around the regex. But can we get the captures
+  # TODO out of that ?
   my $amr = [];
-  while ( $amr_string =~ m/^((([A-Za-z0-9\-\/\(\)\s]+);([SIRU])(;(?=[\w;])((lt|le|eq|gt|ge)?(((\d+)?\.)?\d+))?(;(\w+))?)?),?\s*)+$/g) {
+  while ( $amr_string =~ m/(([A-Za-z0-9\-\/\(\)\s]+);([SIRU])(;(?=[\w;])((lt|le|eq|gt|ge)?(((\d+)?\.)?\d+))?(;(\w+))?)?),?\s*/g) {
     push @$amr,
       {
         antimicrobial_name => lc $2,
         susceptibility     => uc $3,
-        mic                => $5,
-        equality           => lc( $4 || 'eq' ),
-        method             => $12
+        mic                => $7,
+        equality           => lc( $6 || 'eq' ),
+        method             => $11,
       };
   }
   return $amr;

--- a/t/01_schema.t
+++ b/t/01_schema.t
@@ -54,7 +54,7 @@ $new_m->checklist->{config_file} = 't/data/01_checklist.conf';
 $new_m->_set_fh($m->_fh);
 $new_m->_set_csv($m->_csv);
 
-is_deeply( $m, $new_m, 'manifest generated from the DB matches original' );
+is_deeply( $new_m, $m, 'manifest generated from the DB matches original' );
 
 throws_ok { Schema->get_manifest_object('x') }
   qr/not a valid manifest ID/,


### PR DESCRIPTION
Change to the format of the AMR strings in the checklist necessitated a change to the regex that's used to parse the AMR strings in manifests. This PR updates the code with the new RE and adjusts the capture variable names accordingly.