### PR TITLE
Add a mechanism to delete users

### DIFF
--- a/bin/add_midas_user
+++ b/bin/add_midas_user
@@ -90,7 +90,7 @@ my $user_details = {
 # passphrase is provided, the schema sets a random passphrase and returns it.
 my $returned_passphrase = $schema->add_new_user($user_details);
 
-my $user = $schema->resultset('User')->find($username);
+my $user = $schema->find_user($username);
 die 'ERROR: something went wrong with the creation of the new user'
   unless defined $user;
 

--- a/bin/add_multiple_midas_users
+++ b/bin/add_multiple_midas_users
@@ -78,7 +78,7 @@ while ( <FILE> ) {
   next unless $returned_passphrase;
 
   # get back a User object, so that we can set an API key
-  my $user = $schema->resultset('User')->find($username);
+  my $user = $schema->find_user($username);
   unless ( defined $user ) {
     warn "WARNING: something went wrong with the creation of a new user for '$username'";
     next;

--- a/bin/delete_midas_user
+++ b/bin/delete_midas_user
@@ -1,0 +1,133 @@
+#!/usr/bin/env perl
+#
+# delete_midas_user
+# jt6 20160420 WTSI
+#
+# "delete" a MIDAS website user. The user information isn't really deleted, just
+# flagged as such by setting the "deleted_at" value to a date
+
+# ABSTRACT: delete a MIDAS website user
+# PODNAME: delete_midas_user
+
+use strict;
+use warnings;
+
+use utf8;
+use Config::General;
+use Getopt::Long::Descriptive;
+use Pod::Usage;
+use Bio::HICF::User;
+use Try::Tiny;
+use Carp qw( croak );
+
+#-------------------------------------------------------------------------------
+# configuration
+
+my ( $opt, $usage ) = describe_options(
+  '%c %o',
+  [ 'dbconfig|d=s',   'path to the database configuration file' ],
+  [ 'username|u=s',   'the username for the user to be deleted' ],
+);
+
+pod2usage( { -verbose => 2, -exitval => 0 } ) if $opt->help;
+
+my $config_file = $opt->dbconfig || $ENV{HICF_CONFIG};
+my $username    = $opt->username;
+
+_usage($usage, 'ERROR: you must specify a script configuration file')
+  unless defined $config_file;
+
+_usage($usage, 'ERROR: you must specify a username')
+  unless defined $username;
+
+my $cg;
+try {
+  $cg = Config::General->new($config_file);
+} catch {
+  croak "ERROR: there was a problem reading the configuration file: $_";
+};
+
+my %config = $cg->getall;
+
+my $schema = Bio::HICF::User->connect( @{ $config{database}->{user}->{connect_info} } );
+
+#-------------------------------------------------------------------------------
+
+# get the user row
+my $user = $schema->find_user($username);
+
+# spit the dummy unless the user exists
+die 'ERROR: no such user' unless defined $user;
+
+# delete the user
+$schema->delete_user($username);
+
+# and check that really happened...
+$user = $schema->find_user($username);
+die 'ERROR: there was a problem deleting the user' if defined $user;
+
+print "user '$username' has been deleted";
+
+exit;
+
+#-------------------------------------------------------------------------------
+#- functions -------------------------------------------------------------------
+#-------------------------------------------------------------------------------
+
+sub _usage {
+  my ( $usage, $msg ) = @_;
+
+  print STDERR "$msg\n";
+  print $usage->text;
+  exit 1;
+}
+
+#-------------------------------------------------------------------------------
+
+__END__
+
+=head1 SYNOPSIS
+
+ shell% delete_midas_user -d db.conf -u abc
+ user 'abc' has been deleted
+
+=head1 DESCRIPTION
+
+This script deletes a user from the MIDAS user database. The database
+connection parameters are obtained from the configuration file specified using
+C<--dbconfig>. The username must be supplied.
+
+B<Note> that the user account is not actually deleted, but is flagged as
+deleted in the user-tracking database. Specifically, the C<deleted_at> field
+for the user is set to the date at which the script was run.
+
+=head1 OPTIONS
+
+=over 4
+
+=item -d --dbconfig
+
+configuration file with database connection parameters. B<Required>.
+
+=item -u --username
+
+username for the new user. B<Required>.
+
+=item -h --help
+
+display help text
+
+=back
+
+=head1 SEE ALSO
+
+C<Bio::HICF::Schema>
+C<Bio::HICF::User>
+C<add_midas_user>
+
+=head1 CONTACT
+
+path-help@sanger.ac.uk
+
+=cut
+

--- a/bin/delete_midas_user
+++ b/bin/delete_midas_user
@@ -27,6 +27,7 @@ my ( $opt, $usage ) = describe_options(
   '%c %o',
   [ 'dbconfig|d=s',   'path to the database configuration file' ],
   [ 'username|u=s',   'the username for the user to be deleted' ],
+  [ 'help|h',         'print usage message' ],
 );
 
 pod2usage( { -verbose => 2, -exitval => 0 } ) if $opt->help;
@@ -66,7 +67,7 @@ $schema->delete_user($username);
 $user = $schema->find_user($username);
 die 'ERROR: there was a problem deleting the user' if defined $user;
 
-print "user '$username' has been deleted";
+print "user '$username' has been deleted\n";
 
 exit;
 

--- a/lib/Bio/HICF/User.pm
+++ b/lib/Bio/HICF/User.pm
@@ -45,6 +45,7 @@ use Try::Tiny;
 use Email::Valid;
 use File::Basename;
 use List::MoreUtils qw( mesh );
+use DateTime;
 
 use Bio::Metadata::Types qw( UUID OntologyTerm );
 use Bio::Metadata::Checklist;
@@ -132,6 +133,61 @@ sub add_new_user {
 
 #-------------------------------------------------------------------------------
 
+=head2 find_user($username)
+
+Returns the row for the specified user. Requires one argument, giving the
+username of the user. Croaks if the username is not supplied. Returns undef if
+the username does not return a row.
+
+=cut
+
+sub find_user {
+  my ( $self, $username ) = @_;
+
+  croak 'ERROR: must supply a username'
+    unless defined $username;
+
+  my $user_rs = $self->resultset('User')->search(
+    {
+      username   => $username,
+      deleted_at => undef,
+    }
+  );
+
+  return unless ( defined $user_rs and $user_rs->count == 1 );
+
+  return $user_rs->first;
+}
+
+#-------------------------------------------------------------------------------
+
+=head2 delete_user($username)
+
+Delete the specified user. Requires one argument, the username of the user to
+be deleted. Croaks is a username is not supplied, or if a user with that
+username is not found.
+
+Note that the user account is not really deleted. Instead, its "deleted_at"
+field is set to the current time.
+
+=cut
+
+sub delete_user {
+  my ( $self, $username ) = @_;
+
+  croak 'ERROR: must supply a username'
+    unless defined $username;
+
+  my $user = $self->find_user($username);
+
+  croak "ERROR: user '$username' does not exist"
+    unless defined $user;
+
+  $user->update( { deleted_at => DateTime->now } );
+}
+
+#-------------------------------------------------------------------------------
+
 =head2 update_user($user_details)
 
 Update the details for the specified user. Requires a single argument, a
@@ -182,8 +238,7 @@ sub update_user {
 
   # TODO maybe implement roles
 
-  my $user = $self->resultset('User')
-                  ->find( $column_values->{username} );
+  my $user = $self->find_user( $column_values->{username} );
 
   croak "ERROR: user '$fields->{username}' does not exist; use 'add_user' to add"
     unless defined $user;
@@ -205,8 +260,7 @@ sub set_passphrase {
   croak 'ERROR: must supply a username and a passphrase'
     unless ( defined $username and defined $passphrase );
 
-  my $user = $self->resultset('User')
-                  ->find($username);
+  my $user = $self->find_user($username);
 
   croak "ERROR: user '$username' does not exist; use 'add_user' to add"
     unless defined $user;
@@ -228,7 +282,7 @@ sub reset_passphrase {
 
   croak 'ERROR: must supply a username' unless defined $username;
 
-  my $user = $self->resultset('User')->find($username);
+  my $user = $self->find_user($username);
 
   croak "ERROR: user '$username' does not exist; use 'add_user' to add"
     unless defined $user;
@@ -250,8 +304,7 @@ sub reset_api_key {
 
   croak 'ERROR: must supply a username' unless defined $username;
 
-  my $user = $self->resultset('User')
-                  ->find($username);
+  my $user = $self->find_user($username);
 
   croak "ERROR: user '$username' does not exist; use 'add_user' to add"
     unless defined $user;

--- a/lib/Bio/HICF/User.pm
+++ b/lib/Bio/HICF/User.pm
@@ -188,6 +188,44 @@ sub delete_user {
 
 #-------------------------------------------------------------------------------
 
+=head2 is_deleted($username)
+
+Returns true if the user with the specified username has been deleted, or false
+if the user is still active.
+
+=cut
+
+sub is_deleted {
+  my ( $self, $username ) = @_;
+
+  croak 'ERROR: must supply a username'
+    unless defined $username;
+
+  my $user = $self->resultset('User')->find($username);
+
+  croak "ERROR: user '$username' does not exist"
+    unless defined $user;
+
+  return $user->deleted_at ? 1 : 0;
+}
+
+#-------------------------------------------------------------------------------
+
+=head is_active($username)
+
+Returns true if the user with the specified username is active, or false if the
+user is has been deleted.
+
+=cut
+
+sub is_active {
+  my ( $self, $username ) = @_;
+
+  return $self->is_deleted($username) ? 0 : 1;
+}
+
+#-------------------------------------------------------------------------------
+
 =head2 update_user($user_details)
 
 Update the details for the specified user. Requires a single argument, a

--- a/lib/Bio/HICF/User/Role/User.pm
+++ b/lib/Bio/HICF/User/Role/User.pm
@@ -69,5 +69,32 @@ sub reset_api_key {
 
 #-------------------------------------------------------------------------------
 
+=head2 is_deleted
+
+Returns true if this user is deleted, i.e. has a value for the C<deleted_at>
+field, false otherwise.
+
+=cut
+
+sub is_deleted {
+  my $self = shift;
+
+  return $self->deleted_at ? 1 : 0;
+}
+
+#-------------------------------------------------------------------------------
+
+=head2 is_active
+
+Returns true is this user is active, i.e. not deleted, or false otherwise.
+
+=cut
+
+sub is_active {
+  return ! shift->is_deleted;
+}
+
+#-------------------------------------------------------------------------------
+
 1;
 

--- a/t/09_password_methods.t
+++ b/t/09_password_methods.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 49;
+use Test::More tests => 57;
 use Test::Exception;
 
 #-------------------------------------------------------------------------------
@@ -53,6 +53,12 @@ ok $user = Schema->find_user('user1'), '"find_user" returns a user';
 
 isa_ok $user, 'Bio::HICF::User::Result::User', 'got User row';
 
+ok   Schema->is_active('user1'), 'user is active';
+ok ! Schema->is_deleted('user1'), 'user is not deleted';
+
+ok   $user->is_active, 'user is active';
+ok ! $user->is_deleted, 'user is not deleted';
+
 my $user_row = User->find('user1');
 is $user_row->deleted_at, undef, '"deleted_at" has NO value for live user';
 
@@ -73,6 +79,16 @@ is Schema->find_user('user1'), undef, 'no deleted user via "find_user"';
 
 $user_row = User->find('user1');
 ok $user_row->deleted_at, '"deleted_at" has a value for deleted user';
+
+ok ! Schema->is_active('user1'), 'user is not active';
+ok   Schema->is_deleted('user1'), 'user is deleted';
+
+# because the state of the object in $user is not updated when we run
+# Schema->delete_user, checking it with $user->is_active will give us
+# a result from *before* we ran "delete_user". Instead we need to
+# check with the row that we created after we ran "delete_user".
+ok ! $user_row->is_active, 'user is not active';
+ok   $user_row->is_deleted, 'user is deleted';
 
 # re-enable the deleted user
 $user_row->update( { deleted_at => undef } );


### PR DESCRIPTION
This PR adds a mechanism to the schema for flagging users as deleted. We don't actually want to delete user accounts, because it's good to have them for audit purposes, but we want to flag them as being deleted, by setting their `deleted_at` field in the database to the date/time at which the account was deleted. 

There is also a new script, `delete_midas_user`, that deleted the specified user.